### PR TITLE
Better defaults for affe-{grep,find}-command

### DIFF
--- a/affe.el
+++ b/affe.el
@@ -45,6 +45,7 @@
 (defcustom affe-find-command
   (cond
    ((executable-find "fd") "fd --color=never --type f")
+   ((executable-find "rg") "rg --color=never --files")
    ((executable-find "find") "find -not ( -wholename */.* -prune ) -type f"))
   "Find file command."
   :type 'string)

--- a/affe.el
+++ b/affe.el
@@ -43,7 +43,9 @@
   :type 'integer)
 
 (defcustom affe-find-command
-  "find -not ( -wholename */.* -prune ) -type f"
+  (cond
+   ((executable-find "fd") "fd --type f")
+   ((executable-find "find") "find -not ( -wholename */.* -prune ) -type f"))
   "Find file command."
   :type 'string)
 

--- a/affe.el
+++ b/affe.el
@@ -48,7 +48,9 @@
   :type 'string)
 
 (defcustom affe-grep-command
-  "rg --null --color=never --max-columns=1000 --no-heading --line-number -v ^$ ."
+  (cond
+   ((executable-find "rg") "rg --null --color=never --max-columns=1000 --no-heading --line-number -v ^$ .")
+   ((executable-find "grep") "grep -I -r --exclude=.* --exclude-dir=.* --null --color=never --line-number -v ^$"))
   "Grep command."
   :type 'string)
 

--- a/affe.el
+++ b/affe.el
@@ -44,14 +44,14 @@
 
 (defcustom affe-find-command
   (cond
-   ((executable-find "fd") "fd --type f")
+   ((executable-find "fd") "fd --color=never --type f")
    ((executable-find "find") "find -not ( -wholename */.* -prune ) -type f"))
   "Find file command."
   :type 'string)
 
 (defcustom affe-grep-command
   (cond
-   ((executable-find "rg") "rg --null --color=never --max-columns=1000 --no-heading --line-number -v ^$ .")
+   ((executable-find "rg") "rg --null --max-columns=1000 --no-heading --line-number -v ^$ .")
    ((executable-find "grep") "grep -I -r --exclude=.* --exclude-dir=.* --null --color=never --line-number -v ^$"))
   "Grep command."
   :type 'string)


### PR DESCRIPTION
So I make a new PR since I somehow messed with Git hard enough to make my old one vanish... Sorry 'bout that...

This should make affe default to fd and/or ripgrep when they are available, and fall back to find/grep when they are not.