### PR TITLE
Fix problem with no preview when affe-grep from a subdir of a project

### DIFF
--- a/affe.el
+++ b/affe.el
@@ -169,7 +169,8 @@ ARGS are passed to `consult--read'."
     (apply #'consult--read
            `(,@args :prompt ,(car prompt-dir)
                     :sort nil
-                    :require-match t))))
+                    :require-match t
+                    :state ,(consult--grep-state)))))
 
 ;;;###autoload
 (defun affe-grep (&optional dir initial)
@@ -187,8 +188,7 @@ ARGS are passed to `consult--read'."
    :category 'consult-grep
    :add-history (thing-at-point 'symbol)
    :lookup #'consult--lookup-member
-   :group #'consult--grep-group
-   :state (consult--grep-state)))
+   :group #'consult--grep-group))
 
 ;;;###autoload
 (defun affe-find (&optional dir initial)


### PR DESCRIPTION
I set a manual preview key for `affe-grep` as follows.

```
(consult-customize affe-grep :preview-key (kbd "M-."))
```

Assume that the current buffer is visiting `~/proj/a/b/c/d/e.txt`, where `~/proj` is the root directory of the project.

Invoke `affe-grep` and press `M-.`, I can't preview the file.

The reason is as follows.

When consult opens a file for preview, a function returned from `consult--temporary-files` searches it from `default-directory`.
Therefore, `default-directory` must be properly set before the call of `consult--temporary-files`.
Since `consult--grep-state` calls `consult--temporary-files`, `consult--grep-state` must be called after `default-directory` is set.
